### PR TITLE
Implement shared base configs and change detection

### DIFF
--- a/docs/subreddit/components/README.md
+++ b/docs/subreddit/components/README.md
@@ -70,6 +70,7 @@ This list is not exhaustive. [For complete documentation on a subreddit's config
     * [Rule Order](#rule-order)
   * [Configuration Re-use and Caching](#configuration-re-use-and-caching)
   * [Partial Configurations](#partial-configurations)
+    * [Sharing Configs Between Subreddits](#sharing-full-configs-as-runs)
 * [Subreddit-ready examples](#subreddit-ready-examples)
 
 # Runs
@@ -1246,6 +1247,49 @@ The object contains:
 * `path` -- REQUIRED string following rules above
 * `ttl` -- OPTIONAL, number of seconds to cache the URL result. Defaults to `WikiTTL`
 
+### Sharing Full Configs as Runs
+
+If the Fragment fetched by CM is a "full config" (including `runs`, `polling`, etc...) that could be used as a valid config for another subreddit then CM will extract and use the **Runs** from that config.
+
+**However, the config must also explicitly allow access for use as a Fragment.** This is to prevent subreddits that share a Bot account from accidentally (or intentionally) gaining access to another subreddit's config with permissions.
+
+#### Sharing
+
+The config that will be shared (accessed at `wiki:botconfig/contextbot|SharingSubreddit`) must have the `sharing` property defined at its top-level. If `sharing` is not defined access will be denied for all subreddits.
+
+```yaml
+sharing: false # deny access to all subreddits (default when sharing is not defined)
+
+polling:
+  - newComm
+
+runs:
+  # ...
+```
+
+```yaml
+sharing: true # any subreddit can use this config (reddit account must also be able to access wiki page)
+```
+
+```yaml
+# when a list is given all subreddit names that match any from the list are ALLOWED to access the config
+# list can be regular expressions or case-insensitive strings
+sharing:
+  - mealtimevideos
+  - videos
+  - '/Ask.*/i' 
+```
+
+```yaml
+# if `exclude` is used then any subreddit name that is NOT on this list can access the config
+# list can be regular expressions or case-insensitive strings
+sharing:
+  exclude:
+    - mealtimevideos
+    - videos
+    - '/Ask.*/i' 
+```
+
 #### Examples
 
 **Replacing A Rule with a URL Fragment**
@@ -1268,7 +1312,7 @@ runs:
             subreddits:
               - MyBadSubreddit
         window: 7 days
-      actions:
+    actions:
       - kind: report
         content: 'uses freekarma subreddits and bad subreddits'
 ```
@@ -1301,6 +1345,33 @@ runs:
     actions:
       - kind: report
         content: 'uses freekarma subreddits'
+```
+
+**Using Another Subreddit's Config**
+
+```yaml
+runs:
+- `wiki:botconfig/contextbot|SharingSubreddit`
+- name: MySubredditSpecificRun
+  checks:
+  - name: Free Karma Alert
+    description: Check if author has posted in 'freekarma' subreddits
+    kind: submission
+    rules:
+      - 'wiki:freeKarmaFrag'
+    actions:
+      - kind: report
+        content: 'uses freekarma subreddits'
+```
+
+In `r/SharingSubreddit`:
+
+```yaml
+sharing: true
+
+runs:
+  - name: ARun
+    # ...
 ```
 
 # Subreddit-Ready Examples

--- a/src/Bot/ResourcesManager.ts
+++ b/src/Bot/ResourcesManager.ts
@@ -96,7 +96,7 @@ export class BotResourcesManager {
         this.cacheType = options.store;
 
         const cache = createCacheManager(options);
-        this.defaultCache = new CMCache(cache, options, true, this.ttlDefaults, this.logger);
+        this.defaultCache = new CMCache(cache, options, true, caching.provider.prefix, this.ttlDefaults, this.logger);
     }
 
     get(subName: string): SubredditResources | undefined {
@@ -147,7 +147,7 @@ export class BotResourcesManager {
             } else if(res !== undefined && res.cache.equalProvider(candidateProvider)) {
                 opts.cache = res.cache;
             } else {
-                opts.cache = new CMCache(createCacheManager(candidateProvider), candidateProvider, false, opts.ttl, this.logger);
+                opts.cache = new CMCache(createCacheManager(candidateProvider), candidateProvider, false, this.defaultCache.providerOptions.prefix, opts.ttl, this.logger);
                 await runMigrations(opts.cache.cache, opts.cache.logger, candidateProvider.prefix);
             }
 

--- a/src/Bot/ResourcesManager.ts
+++ b/src/Bot/ResourcesManager.ts
@@ -1,7 +1,13 @@
 import {SPoll} from "../Subreddit/Streams";
 import Snoowrap from "snoowrap";
 import {Cache} from "cache-manager";
-import {BotInstanceConfig, StrongCache, ThirdPartyCredentialsJsonConfig, TTLConfig} from "../Common/interfaces";
+import {
+    BotInstanceConfig,
+    StrongCache,
+    StrongTTLConfig,
+    ThirdPartyCredentialsJsonConfig,
+    TTLConfig
+} from "../Common/interfaces";
 import winston, {Logger} from "winston";
 import {DataSource, Repository} from "typeorm";
 import {
@@ -9,27 +15,25 @@ import {
 } from "../Common/Infrastructure/Atomic";
 import {InvokeeType} from "../Common/Entities/InvokeeType";
 import {RunStateType} from "../Common/Entities/RunStateType";
-import {buildCacheOptionsFromProvider, buildCachePrefix, cacheStats, createCacheManager} from "../util";
+import {buildCachePrefix, cacheStats, mergeArr, toStrongTTLConfig} from "../util";
 import objectHash from "object-hash";
 import {runMigrations} from "../Common/Migrations/CacheMigrationUtils";
 import {CMError} from "../Utils/Errors";
 import {DEFAULT_FOOTER, SubredditResources} from "../Subreddit/SubredditResources";
 import {SubredditResourceConfig, SubredditResourceOptions} from "../Common/Subreddit/SubredditResourceInterfaces";
+import {buildCacheOptionsFromProvider, CMCache, createCacheManager} from "../Common/Cache";
 
 export class BotResourcesManager {
     resources: Map<string, SubredditResources> = new Map();
     authorTTL: number = 10000;
     enabled: boolean = true;
     modStreams: Map<string, SPoll<Snoowrap.Submission | Snoowrap.Comment>> = new Map();
-    defaultCache: Cache;
+    defaultCache: CMCache;
     defaultCacheConfig: StrongCache
     defaultCacheMigrated: boolean = false;
     cacheType: string = 'none';
     cacheHash: string;
-    ttlDefaults: Required<TTLConfig>;
-    actionedEventsMaxDefault?: number;
-    actionedEventsDefault: number;
-    pruneInterval: any;
+    ttlDefaults: StrongTTLConfig
     defaultThirdPartyCredentials: ThirdPartyCredentialsJsonConfig;
     logger: Logger;
     botAccount?: string;
@@ -53,8 +57,6 @@ export class BotResourcesManager {
                 modNotesTTL,
                 selfTTL,
                 provider,
-                actionedEventsMax,
-                actionedEventsDefault,
             },
             name,
             credentials: {
@@ -68,12 +70,12 @@ export class BotResourcesManager {
             caching,
         } = config;
         caching.provider.prefix = buildCachePrefix([caching.provider.prefix, 'SHARED']);
-        const {actionedEventsMax: eMax, actionedEventsDefault: eDef, ...relevantCacheSettings} = caching;
+        const {...relevantCacheSettings} = caching;
         this.cacheHash = objectHash.sha1(relevantCacheSettings);
         this.defaultCacheConfig = caching;
         this.defaultThirdPartyCredentials = thirdParty;
         this.defaultDatabase = database;
-        this.ttlDefaults = {
+        this.ttlDefaults = toStrongTTLConfig({
             authorTTL,
             userNotesTTL,
             wikiTTL,
@@ -83,7 +85,7 @@ export class BotResourcesManager {
             subredditTTL,
             selfTTL,
             modNotesTTL
-        };
+        });
         this.botName = name as string;
         this.logger = logger;
         this.invokeeRepo = this.defaultDatabase.getRepository(InvokeeType);
@@ -92,23 +94,9 @@ export class BotResourcesManager {
 
         const options = provider;
         this.cacheType = options.store;
-        this.actionedEventsMaxDefault = actionedEventsMax;
-        this.actionedEventsDefault = actionedEventsDefault;
-        this.defaultCache = createCacheManager(options);
-        if (this.cacheType === 'memory') {
-            const min = Math.min(...([this.ttlDefaults.wikiTTL, this.ttlDefaults.authorTTL, this.ttlDefaults.userNotesTTL].filter(x => typeof x === 'number' && x !== 0) as number[]));
-            if (min > 0) {
-                // set default prune interval
-                this.pruneInterval = setInterval(() => {
-                    // @ts-ignore
-                    this.defaultCache?.store.prune();
-                    // kinda hacky but whatever
-                    const logger = winston.loggers.get('app');
-                    logger.debug('Pruned Shared Cache');
-                    // prune interval should be twice the smallest TTL
-                }, min * 1000 * 2)
-            }
-        }
+
+        const cache = createCacheManager(options);
+        this.defaultCache = new CMCache(cache, options, true, this.ttlDefaults, this.logger);
     }
 
     get(subName: string): SubredditResources | undefined {
@@ -122,17 +110,7 @@ export class BotResourcesManager {
         let hash = 'default';
         const {caching, credentials, retention, ...init} = initOptions;
 
-        // const bEntity = await this.defaultDatabase.getRepository(Bot).findOne({where: {name: this.botName}}) as Bot;
-        // //const subreddit = this.defaultDatabase.getRepository(SubredditEntity).findOne({name: initOptions.subreddit.display_name});
-        // const mEntity = await this.defaultDatabase.getRepository(Manager).findOne({
-        //     where: {
-        //         name: subName,
-        //         bot: {
-        //             id: bEntity.id
-        //         }
-        //     },
-        //     relations: ['bot']
-        // });
+        const res = this.get(subName);
 
         let opts: SubredditResourceOptions = {
             cache: this.defaultCache,
@@ -141,7 +119,6 @@ export class BotResourcesManager {
             ttl: this.ttlDefaults,
             thirdPartyCredentials: credentials ?? this.defaultThirdPartyCredentials,
             prefix: this.defaultCacheConfig.provider.prefix,
-            actionedEventsMax: this.actionedEventsMaxDefault !== undefined ? Math.min(this.actionedEventsDefault, this.actionedEventsMaxDefault) : this.actionedEventsDefault,
             database: this.defaultDatabase,
             botName: this.botName,
             retention: retention ?? this.retention,
@@ -151,66 +128,47 @@ export class BotResourcesManager {
         if (caching !== undefined) {
             const {
                 provider = this.defaultCacheConfig.provider,
-                actionedEventsMax = this.actionedEventsDefault,
                 ...rest
             } = caching;
-            let cacheConfig = {
-                provider: buildCacheOptionsFromProvider(provider),
-                ttl: {
-                    ...this.ttlDefaults,
-                    ...rest
-                },
+            
+            opts.ttl = toStrongTTLConfig({
+                ...this.ttlDefaults,
+                ...rest
+            });
+            
+            const candidateProvider = buildCacheOptionsFromProvider(provider);
+
+            const defaultPrefix = candidateProvider.prefix;
+            const subPrefix = defaultPrefix === this.defaultCacheConfig.provider.prefix ? buildCachePrefix([(defaultPrefix !== undefined ? defaultPrefix.replace('SHARED', '') : defaultPrefix), subName]) : candidateProvider.prefix;
+            candidateProvider.prefix = subPrefix;
+
+            if(this.defaultCache.equalProvider(candidateProvider)) {
+                opts.cache = this.defaultCache;
+            } else if(res !== undefined && res.cache.equalProvider(candidateProvider)) {
+                opts.cache = res.cache;
+            } else {
+                opts.cache = new CMCache(createCacheManager(candidateProvider), candidateProvider, false, opts.ttl, this.logger, candidateProvider.prefix);
+                await runMigrations(opts.cache.cache, opts.cache.logger, candidateProvider.prefix);
             }
-            hash = objectHash.sha1(cacheConfig);
-            // only need to create private if there settings are actually different than the default
-            if (hash !== this.cacheHash) {
-                const {provider: trueProvider, ...trueRest} = cacheConfig;
-                const defaultPrefix = trueProvider.prefix;
-                const subPrefix = defaultPrefix === this.defaultCacheConfig.provider.prefix ? buildCachePrefix([(defaultPrefix !== undefined ? defaultPrefix.replace('SHARED', '') : defaultPrefix), subName]) : trueProvider.prefix;
-                trueProvider.prefix = subPrefix;
-                const eventsMax = this.actionedEventsMaxDefault !== undefined ? Math.min(actionedEventsMax, this.actionedEventsMaxDefault) : actionedEventsMax;
-                opts = {
-                    cache: createCacheManager(trueProvider),
-                    actionedEventsMax: eventsMax,
-                    cacheType: trueProvider.store,
-                    cacheSettingsHash: hash,
-                    thirdPartyCredentials: credentials ?? this.defaultThirdPartyCredentials,
-                    prefix: subPrefix,
-                    botName: this.botName,
-                    database: this.defaultDatabase,
-                    retention: retention ?? this.retention,
-                    ...init,
-                    ...trueRest,
-                };
-                await runMigrations(opts.cache, opts.logger, trueProvider.prefix);
-            }
+
         } else if (!this.defaultCacheMigrated) {
-            await runMigrations(this.defaultCache, this.logger, opts.prefix);
+            await runMigrations(this.defaultCache.cache, this.logger, opts.prefix);
             this.defaultCacheMigrated = true;
         }
 
         let resource: SubredditResources;
-        const res = this.get(subName);
-        if (res === undefined || res.cacheSettingsHash !== hash) {
+        if (res === undefined) {
             resource = new SubredditResources(subName, {
                 ...opts,
-                delayedItems: res?.delayedItems,
                 botAccount: this.botAccount
             });
-            await resource.initStats();
-            resource.setHistoricalSaveInterval();
             this.resources.set(subName, resource);
         } else {
             // just set non-cache related settings
             resource = res;
             resource.botAccount = this.botAccount;
-            if (opts.footer !== resource.footer) {
-                resource.footer = opts.footer || DEFAULT_FOOTER;
-            }
-            // reset cache stats when configuration is reloaded
-            resource.subredditStats.stats.cache = cacheStats();
         }
-        await resource.initDatabaseDelayedActivities();
+        await resource.configure(opts);
 
         return resource;
     }

--- a/src/Bot/ResourcesManager.ts
+++ b/src/Bot/ResourcesManager.ts
@@ -147,7 +147,7 @@ export class BotResourcesManager {
             } else if(res !== undefined && res.cache.equalProvider(candidateProvider)) {
                 opts.cache = res.cache;
             } else {
-                opts.cache = new CMCache(createCacheManager(candidateProvider), candidateProvider, false, opts.ttl, this.logger, candidateProvider.prefix);
+                opts.cache = new CMCache(createCacheManager(candidateProvider), candidateProvider, false, opts.ttl, this.logger);
                 await runMigrations(opts.cache.cache, opts.cache.logger, candidateProvider.prefix);
             }
 

--- a/src/Bot/ResourcesManager.ts
+++ b/src/Bot/ResourcesManager.ts
@@ -1,0 +1,266 @@
+import {SPoll} from "../Subreddit/Streams";
+import Snoowrap from "snoowrap";
+import {Cache} from "cache-manager";
+import {BotInstanceConfig, StrongCache, ThirdPartyCredentialsJsonConfig, TTLConfig} from "../Common/interfaces";
+import winston, {Logger} from "winston";
+import {DataSource, Repository} from "typeorm";
+import {
+    EventRetentionPolicyRange
+} from "../Common/Infrastructure/Atomic";
+import {InvokeeType} from "../Common/Entities/InvokeeType";
+import {RunStateType} from "../Common/Entities/RunStateType";
+import {buildCacheOptionsFromProvider, buildCachePrefix, cacheStats, createCacheManager} from "../util";
+import objectHash from "object-hash";
+import {runMigrations} from "../Common/Migrations/CacheMigrationUtils";
+import {CMError} from "../Utils/Errors";
+import {DEFAULT_FOOTER, SubredditResources} from "../Subreddit/SubredditResources";
+import {SubredditResourceConfig, SubredditResourceOptions} from "../Common/Subreddit/SubredditResourceInterfaces";
+
+export class BotResourcesManager {
+    resources: Map<string, SubredditResources> = new Map();
+    authorTTL: number = 10000;
+    enabled: boolean = true;
+    modStreams: Map<string, SPoll<Snoowrap.Submission | Snoowrap.Comment>> = new Map();
+    defaultCache: Cache;
+    defaultCacheConfig: StrongCache
+    defaultCacheMigrated: boolean = false;
+    cacheType: string = 'none';
+    cacheHash: string;
+    ttlDefaults: Required<TTLConfig>;
+    actionedEventsMaxDefault?: number;
+    actionedEventsDefault: number;
+    pruneInterval: any;
+    defaultThirdPartyCredentials: ThirdPartyCredentialsJsonConfig;
+    logger: Logger;
+    botAccount?: string;
+    defaultDatabase: DataSource
+    botName!: string
+    retention?: EventRetentionPolicyRange
+
+    invokeeRepo: Repository<InvokeeType>
+    runTypeRepo: Repository<RunStateType>
+
+    constructor(config: BotInstanceConfig, logger: Logger) {
+        const {
+            caching: {
+                authorTTL,
+                userNotesTTL,
+                wikiTTL,
+                commentTTL,
+                submissionTTL,
+                subredditTTL,
+                filterCriteriaTTL,
+                modNotesTTL,
+                selfTTL,
+                provider,
+                actionedEventsMax,
+                actionedEventsDefault,
+            },
+            name,
+            credentials: {
+                reddit,
+                ...thirdParty
+            },
+            database,
+            databaseConfig: {
+                retention
+            } = {},
+            caching,
+        } = config;
+        caching.provider.prefix = buildCachePrefix([caching.provider.prefix, 'SHARED']);
+        const {actionedEventsMax: eMax, actionedEventsDefault: eDef, ...relevantCacheSettings} = caching;
+        this.cacheHash = objectHash.sha1(relevantCacheSettings);
+        this.defaultCacheConfig = caching;
+        this.defaultThirdPartyCredentials = thirdParty;
+        this.defaultDatabase = database;
+        this.ttlDefaults = {
+            authorTTL,
+            userNotesTTL,
+            wikiTTL,
+            commentTTL,
+            submissionTTL,
+            filterCriteriaTTL,
+            subredditTTL,
+            selfTTL,
+            modNotesTTL
+        };
+        this.botName = name as string;
+        this.logger = logger;
+        this.invokeeRepo = this.defaultDatabase.getRepository(InvokeeType);
+        this.runTypeRepo = this.defaultDatabase.getRepository(RunStateType);
+        this.retention = retention;
+
+        const options = provider;
+        this.cacheType = options.store;
+        this.actionedEventsMaxDefault = actionedEventsMax;
+        this.actionedEventsDefault = actionedEventsDefault;
+        this.defaultCache = createCacheManager(options);
+        if (this.cacheType === 'memory') {
+            const min = Math.min(...([this.ttlDefaults.wikiTTL, this.ttlDefaults.authorTTL, this.ttlDefaults.userNotesTTL].filter(x => typeof x === 'number' && x !== 0) as number[]));
+            if (min > 0) {
+                // set default prune interval
+                this.pruneInterval = setInterval(() => {
+                    // @ts-ignore
+                    this.defaultCache?.store.prune();
+                    // kinda hacky but whatever
+                    const logger = winston.loggers.get('app');
+                    logger.debug('Pruned Shared Cache');
+                    // prune interval should be twice the smallest TTL
+                }, min * 1000 * 2)
+            }
+        }
+    }
+
+    get(subName: string): SubredditResources | undefined {
+        if (this.resources.has(subName)) {
+            return this.resources.get(subName) as SubredditResources;
+        }
+        return undefined;
+    }
+
+    async set(subName: string, initOptions: SubredditResourceConfig): Promise<SubredditResources> {
+        let hash = 'default';
+        const {caching, credentials, retention, ...init} = initOptions;
+
+        // const bEntity = await this.defaultDatabase.getRepository(Bot).findOne({where: {name: this.botName}}) as Bot;
+        // //const subreddit = this.defaultDatabase.getRepository(SubredditEntity).findOne({name: initOptions.subreddit.display_name});
+        // const mEntity = await this.defaultDatabase.getRepository(Manager).findOne({
+        //     where: {
+        //         name: subName,
+        //         bot: {
+        //             id: bEntity.id
+        //         }
+        //     },
+        //     relations: ['bot']
+        // });
+
+        let opts: SubredditResourceOptions = {
+            cache: this.defaultCache,
+            cacheType: this.cacheType,
+            cacheSettingsHash: hash,
+            ttl: this.ttlDefaults,
+            thirdPartyCredentials: credentials ?? this.defaultThirdPartyCredentials,
+            prefix: this.defaultCacheConfig.provider.prefix,
+            actionedEventsMax: this.actionedEventsMaxDefault !== undefined ? Math.min(this.actionedEventsDefault, this.actionedEventsMaxDefault) : this.actionedEventsDefault,
+            database: this.defaultDatabase,
+            botName: this.botName,
+            retention: retention ?? this.retention,
+            ...init,
+        };
+
+        if (caching !== undefined) {
+            const {
+                provider = this.defaultCacheConfig.provider,
+                actionedEventsMax = this.actionedEventsDefault,
+                ...rest
+            } = caching;
+            let cacheConfig = {
+                provider: buildCacheOptionsFromProvider(provider),
+                ttl: {
+                    ...this.ttlDefaults,
+                    ...rest
+                },
+            }
+            hash = objectHash.sha1(cacheConfig);
+            // only need to create private if there settings are actually different than the default
+            if (hash !== this.cacheHash) {
+                const {provider: trueProvider, ...trueRest} = cacheConfig;
+                const defaultPrefix = trueProvider.prefix;
+                const subPrefix = defaultPrefix === this.defaultCacheConfig.provider.prefix ? buildCachePrefix([(defaultPrefix !== undefined ? defaultPrefix.replace('SHARED', '') : defaultPrefix), subName]) : trueProvider.prefix;
+                trueProvider.prefix = subPrefix;
+                const eventsMax = this.actionedEventsMaxDefault !== undefined ? Math.min(actionedEventsMax, this.actionedEventsMaxDefault) : actionedEventsMax;
+                opts = {
+                    cache: createCacheManager(trueProvider),
+                    actionedEventsMax: eventsMax,
+                    cacheType: trueProvider.store,
+                    cacheSettingsHash: hash,
+                    thirdPartyCredentials: credentials ?? this.defaultThirdPartyCredentials,
+                    prefix: subPrefix,
+                    botName: this.botName,
+                    database: this.defaultDatabase,
+                    retention: retention ?? this.retention,
+                    ...init,
+                    ...trueRest,
+                };
+                await runMigrations(opts.cache, opts.logger, trueProvider.prefix);
+            }
+        } else if (!this.defaultCacheMigrated) {
+            await runMigrations(this.defaultCache, this.logger, opts.prefix);
+            this.defaultCacheMigrated = true;
+        }
+
+        let resource: SubredditResources;
+        const res = this.get(subName);
+        if (res === undefined || res.cacheSettingsHash !== hash) {
+            resource = new SubredditResources(subName, {
+                ...opts,
+                delayedItems: res?.delayedItems,
+                botAccount: this.botAccount
+            });
+            await resource.initStats();
+            resource.setHistoricalSaveInterval();
+            this.resources.set(subName, resource);
+        } else {
+            // just set non-cache related settings
+            resource = res;
+            resource.botAccount = this.botAccount;
+            if (opts.footer !== resource.footer) {
+                resource.footer = opts.footer || DEFAULT_FOOTER;
+            }
+            // reset cache stats when configuration is reloaded
+            resource.stats.cache = cacheStats();
+        }
+        await resource.initDatabaseDelayedActivities();
+
+        return resource;
+    }
+
+    async destroy(subName: string) {
+        const res = this.get(subName);
+        if (res !== undefined) {
+            await res.destroy();
+            this.resources.delete(subName);
+        }
+    }
+
+    async getPendingSubredditInvites(): Promise<(string[])> {
+        const subredditNames = await this.defaultCache.get(`modInvites`);
+        if (subredditNames !== undefined && subredditNames !== null) {
+            return subredditNames as string[];
+        }
+        return [];
+    }
+
+    async addPendingSubredditInvite(subreddit: string): Promise<void> {
+        if (subreddit === null || subreddit === undefined || subreddit == '') {
+            throw new CMError('Subreddit name cannot be empty');
+        }
+        let subredditNames = await this.defaultCache.get(`modInvites`) as (string[] | undefined | null);
+        if (subredditNames === undefined || subredditNames === null) {
+            subredditNames = [];
+        }
+        const cleanName = subreddit.trim();
+
+        if (subredditNames.some(x => x.trim().toLowerCase() === cleanName.toLowerCase())) {
+            throw new CMError(`An invite for the Subreddit '${subreddit}' already exists`);
+        }
+        subredditNames.push(cleanName);
+        await this.defaultCache.set(`modInvites`, subredditNames, {ttl: 0});
+        return;
+    }
+
+    async deletePendingSubredditInvite(subreddit: string): Promise<void> {
+        let subredditNames = await this.defaultCache.get(`modInvites`) as (string[] | undefined | null);
+        if (subredditNames === undefined || subredditNames === null) {
+            subredditNames = [];
+        }
+        subredditNames = subredditNames.filter(x => x.toLowerCase() !== subreddit.trim().toLowerCase());
+        await this.defaultCache.set(`modInvites`, subredditNames, {ttl: 0});
+        return;
+    }
+
+    async clearPendingSubredditInvites(): Promise<void> {
+        await this.defaultCache.del(`modInvites`);
+        return;
+    }
+}

--- a/src/Bot/ResourcesManager.ts
+++ b/src/Bot/ResourcesManager.ts
@@ -208,7 +208,7 @@ export class BotResourcesManager {
                 resource.footer = opts.footer || DEFAULT_FOOTER;
             }
             // reset cache stats when configuration is reloaded
-            resource.stats.cache = cacheStats();
+            resource.subredditStats.stats.cache = cacheStats();
         }
         await resource.initDatabaseDelayedActivities();
 

--- a/src/Bot/index.ts
+++ b/src/Bot/index.ts
@@ -25,7 +25,6 @@ import {
 import {Manager} from "../Subreddit/Manager";
 import {ExtendedSnoowrap, ProxiedSnoowrap} from "../Utils/SnoowrapClients";
 import {CommentStream, ModQueueStream, SPoll, SubmissionStream, UnmoderatedStream} from "../Subreddit/Streams";
-import {BotResourcesManager} from "../Subreddit/SubredditResources";
 import LoggedError from "../Utils/LoggedError";
 import pEvent from "p-event";
 import {
@@ -63,6 +62,7 @@ import {Guest, GuestEntityData} from "../Common/Entities/Guest/GuestInterfaces";
 import {guestEntitiesToAll, guestEntityToApiGuest} from "../Common/Entities/Guest/GuestEntity";
 import {SubredditInvite} from "../Common/Entities/SubredditInvite";
 import {dayjsDTFormat} from "../Common/defaults";
+import {BotResourcesManager} from "./ResourcesManager";
 
 class Bot implements BotInstanceFunctions {
 

--- a/src/Common/Cache/index.ts
+++ b/src/Common/Cache/index.ts
@@ -1,0 +1,204 @@
+import {CacheProvider} from "../Infrastructure/Atomic";
+import {CacheOptions, StrongTTLConfig} from "../interfaces";
+import {cacheOptDefaults} from "../defaults";
+import cacheManager, {Cache, CachingConfig, WrapArgsType} from "cache-manager";
+import redisStore from "cache-manager-redis-store";
+import {create as createMemoryStore} from "../../Utils/memoryStore";
+import winston, {Logger} from "winston";
+import {mergeArr, parseStringToRegex, redisScanIterator} from "../../util";
+import globrex from "globrex";
+import objectHash from "object-hash";
+
+export const buildCacheOptionsFromProvider = (provider: CacheProvider | any): CacheOptions => {
+    if (typeof provider === 'string') {
+        return {
+            store: provider as CacheProvider,
+            ...cacheOptDefaults
+        }
+    }
+    return {
+        store: 'memory',
+        ...cacheOptDefaults,
+        ...provider,
+    }
+}
+export const createCacheManager = (options: CacheOptions): Cache => {
+    const {store, max, ttl = 60, host = 'localhost', port, auth_pass, db, ...rest} = options;
+    switch (store) {
+        case 'none':
+            return cacheManager.caching({store: 'none', max, ttl});
+        case 'redis':
+            return cacheManager.caching({
+                store: redisStore,
+                host,
+                port,
+                auth_pass,
+                db,
+                ttl,
+                ...rest,
+            });
+        case 'memory':
+        default:
+            //return cacheManager.caching({store: 'memory', max, ttl});
+            return cacheManager.caching({store: {create: createMemoryStore}, max, ttl, shouldCloneBeforeSet: false});
+    }
+}
+
+export class CMCache {
+    pruneInterval?: any;
+    prefix?: string
+    cache: Cache
+    isDefaultCache: boolean
+    providerOptions: CacheOptions;
+    logger!: Logger;
+
+    constructor(cache: Cache, providerOptions: CacheOptions, defaultCache: boolean, ttls: Partial<StrongTTLConfig>, logger: Logger, prefix?: string) {
+        this.cache = cache;
+        this.providerOptions = providerOptions
+        this.prefix = prefix;
+        this.isDefaultCache = defaultCache;
+
+        this.setLogger(logger);
+
+        this.setPruneInterval(ttls);
+    }
+
+    setLogger(logger: Logger) {
+        this.logger = logger.child({labels: ['Cache']}, mergeArr);
+    }
+
+    equalProvider(candidate: CacheOptions) {
+        return objectHash.sha1(candidate) === objectHash.sha1(this.providerOptions);
+    }
+
+    setPruneInterval(ttls: Partial<StrongTTLConfig>) {
+        if (this.providerOptions.store === 'memory' && !this.isDefaultCache) {
+            if (this.pruneInterval !== undefined) {
+                clearInterval(this.pruneInterval);
+            }
+            const min = Math.min(60, ...Object.values(ttls).filter(x => typeof x === 'number' && x !== 0) as number[]);
+            if (min > 0) {
+                // set default prune interval
+                this.pruneInterval = setInterval(() => {
+                    // @ts-ignore
+                    this.cache?.store.prune();
+                    this.logger.debug('Pruned cache');
+                    // prune interval should be twice the smallest TTL
+                }, min * 1000 * 2)
+            }
+        }
+    }
+
+    async getCacheKeyCount() {
+        if (this.cache.store.keys !== undefined) {
+            if (this.providerOptions.store === 'redis') {
+                const keys = await this.cache.store.keys(`${this.prefix}*`);
+                return keys.length;
+            }
+            return (await this.cache.store.keys()).length;
+        }
+        return 0;
+    }
+
+    async interactWithCacheByKeyPattern(pattern: string | RegExp, action: 'get' | 'delete') {
+        let patternIsReg = pattern instanceof RegExp;
+        let regPattern: RegExp;
+        let globPattern = pattern;
+
+        const cacheDict: Record<string, any> = {};
+
+        if (typeof pattern === 'string') {
+            const possibleRegPattern = parseStringToRegex(pattern, 'ig');
+            if (possibleRegPattern !== undefined) {
+                regPattern = possibleRegPattern;
+                patternIsReg = true;
+            } else {
+                if (this.prefix !== undefined && !pattern.includes(this.prefix)) {
+                    // need to add wildcard to beginning of pattern so that the regex will still match a key with a prefix
+                    globPattern = `${this.prefix}${pattern}`;
+                }
+                // @ts-ignore
+                const result = globrex(globPattern, {flags: 'i'});
+                regPattern = result.regex;
+            }
+        } else {
+            regPattern = pattern;
+        }
+
+        if (this.providerOptions.store === 'redis') {
+            // @ts-ignore
+            const redisClient = this.cache.store.getClient();
+            if (patternIsReg) {
+                // scan all and test key by regex
+                for await (const key of redisClient.scanIterator()) {
+                    if (regPattern.test(key) && (this.prefix === undefined || key.includes(this.prefix))) {
+                        if (action === 'delete') {
+                            await redisClient.del(key)
+                        } else {
+                            cacheDict[key] = await redisClient.get(key);
+                        }
+                    }
+                }
+            } else {
+                // not a regex means we can use glob pattern (more efficient!)
+                for await (const key of redisScanIterator(redisClient, {MATCH: globPattern})) {
+                    if (action === 'delete') {
+                        await redisClient.del(key)
+                    } else {
+                        cacheDict[key] = await redisClient.get(key);
+                    }
+                }
+            }
+        } else if (this.cache.store.keys !== undefined) {
+            for (const key of await this.cache.store.keys()) {
+                if (regPattern.test(key) && (this.prefix === undefined || key.includes(this.prefix))) {
+                    if (action === 'delete') {
+                        await this.cache.del(key)
+                    } else {
+                        cacheDict[key] = await this.cache.get(key);
+                    }
+                }
+            }
+        }
+        return cacheDict;
+    }
+
+    async deleteCacheByKeyPattern(pattern: string | RegExp) {
+        return await this.interactWithCacheByKeyPattern(pattern, 'delete');
+    }
+
+    async getCacheByKeyPattern(pattern: string | RegExp) {
+        return await this.interactWithCacheByKeyPattern(pattern, 'get');
+    }
+
+    get store() {
+        return this.cache.store;
+    }
+
+    del(key: string): Promise<any> {
+        return this.cache.del(key);
+    }
+
+    get<T>(key: string): Promise<T | undefined> {
+        return this.cache.get(key);
+    }
+
+    reset(): Promise<void> {
+        return this.cache.reset();
+    }
+
+    set<T>(key: string, value: T, options?: CachingConfig): Promise<T> {
+        return this.cache.set(key, value, options);
+    }
+
+    wrap<T>(...args: WrapArgsType<T>[]): Promise<T> {
+        return this.cache.wrap(...args);
+    }
+
+    async destroy() {
+        if (this.pruneInterval !== undefined && this.providerOptions.store === 'memory' && !this.isDefaultCache) {
+            clearInterval(this.pruneInterval);
+            this.cache?.reset();
+        }
+    }
+}

--- a/src/Common/Cache/index.ts
+++ b/src/Common/Cache/index.ts
@@ -23,7 +23,7 @@ export const buildCacheOptionsFromProvider = (provider: CacheProvider | any): Ca
     }
 }
 export const createCacheManager = (options: CacheOptions): Cache => {
-    const {store, max, ttl = 60, host = 'localhost', port, auth_pass, db, ...rest} = options;
+    const {store, max, ttl = 60, host = 'localhost', port, auth_pass, db, prefix, ...rest} = options;
     switch (store) {
         case 'none':
             return cacheManager.caching({store: 'none', max, ttl});
@@ -52,11 +52,11 @@ export class CMCache {
     providerOptions: CacheOptions;
     logger!: Logger;
 
-    constructor(cache: Cache, providerOptions: CacheOptions, defaultCache: boolean, ttls: Partial<StrongTTLConfig>, logger: Logger, prefix?: string) {
+    constructor(cache: Cache, providerOptions: CacheOptions, defaultCache: boolean, ttls: Partial<StrongTTLConfig>, logger: Logger) {
         this.cache = cache;
         this.providerOptions = providerOptions
-        this.prefix = prefix;
         this.isDefaultCache = defaultCache;
+        this.prefix = this.providerOptions.prefix ?? '';
 
         this.setLogger(logger);
 
@@ -176,11 +176,11 @@ export class CMCache {
     }
 
     del(key: string): Promise<any> {
-        return this.cache.del(key);
+        return this.cache.del(`${this.prefix}${key}`);
     }
 
     get<T>(key: string): Promise<T | undefined> {
-        return this.cache.get(key);
+        return this.cache.get(`${this.prefix}${key}`);
     }
 
     reset(): Promise<void> {
@@ -188,10 +188,11 @@ export class CMCache {
     }
 
     set<T>(key: string, value: T, options?: CachingConfig): Promise<T> {
-        return this.cache.set(key, value, options);
+        return this.cache.set(`${this.prefix}${key}`, value, options);
     }
 
     wrap<T>(...args: WrapArgsType<T>[]): Promise<T> {
+        args[0] = `${this.prefix}${args[0]}`;
         return this.cache.wrap(...args);
     }
 

--- a/src/Common/Infrastructure/Atomic.ts
+++ b/src/Common/Infrastructure/Atomic.ts
@@ -294,7 +294,7 @@ export type UserNoteType =
 
 export const userNoteTypes = ['gooduser', 'spamwatch', 'spamwarn', 'abusewarn', 'ban', 'permban', 'botban'];
 
-export type ConfigFragmentParseFunc = (data: object, fetched: boolean) => object | object[];
+export type ConfigFragmentParseFunc = (data: object, fetched: boolean, subreddit?: string) => object | object[];
 
 export interface WikiContext {
     wiki: string

--- a/src/Common/Infrastructure/Atomic.ts
+++ b/src/Common/Infrastructure/Atomic.ts
@@ -294,7 +294,7 @@ export type UserNoteType =
 
 export const userNoteTypes = ['gooduser', 'spamwatch', 'spamwarn', 'abusewarn', 'ban', 'permban', 'botban'];
 
-export type ConfigFragmentValidationFunc = (data: object, fetched: boolean) => boolean;
+export type ConfigFragmentParseFunc = (data: object, fetched: boolean) => object | object[];
 
 export interface WikiContext {
     wiki: string

--- a/src/Common/Subreddit/SubredditResourceInterfaces.ts
+++ b/src/Common/Subreddit/SubredditResourceInterfaces.ts
@@ -1,4 +1,11 @@
-import {ActivityDispatch, CacheConfig, Footer, ThirdPartyCredentialsJsonConfig, TTLConfig} from "../interfaces";
+import {
+    ActivityDispatch,
+    CacheConfig,
+    Footer,
+    StrongTTLConfig,
+    ThirdPartyCredentialsJsonConfig,
+    TTLConfig
+} from "../interfaces";
 import {Cache} from "cache-manager";
 import {Subreddit} from "snoowrap/dist/objects";
 import {DataSource} from "typeorm";
@@ -7,10 +14,11 @@ import {ExtendedSnoowrap} from "../../Utils/SnoowrapClients";
 import {ManagerEntity} from "../Entities/ManagerEntity";
 import {Bot} from "../Entities/Bot";
 import {EventRetentionPolicyRange, StatisticFrequencyOption} from "../Infrastructure/Atomic";
+import {CMCache} from "../Cache";
 
 export interface SubredditResourceOptions extends Footer {
-    ttl: Required<TTLConfig>
-    cache: Cache
+    ttl: StrongTTLConfig
+    cache: CMCache
     cacheType: string;
     cacheSettingsHash: string
     subreddit: Subreddit,
@@ -18,7 +26,6 @@ export interface SubredditResourceOptions extends Footer {
     logger: Logger;
     client: ExtendedSnoowrap;
     prefix?: string;
-    actionedEventsMax: number;
     thirdPartyCredentials: ThirdPartyCredentialsJsonConfig
     delayedItems?: ActivityDispatch[]
     botAccount?: string
@@ -27,6 +34,7 @@ export interface SubredditResourceOptions extends Footer {
     botEntity: Bot
     statFrequency: StatisticFrequencyOption
     retention?: EventRetentionPolicyRange
+    footer?: false | string
 }
 
 export interface SubredditResourceConfig extends Footer {

--- a/src/Common/Subreddit/SubredditResourceInterfaces.ts
+++ b/src/Common/Subreddit/SubredditResourceInterfaces.ts
@@ -1,0 +1,42 @@
+import {ActivityDispatch, CacheConfig, Footer, ThirdPartyCredentialsJsonConfig, TTLConfig} from "../interfaces";
+import {Cache} from "cache-manager";
+import {Subreddit} from "snoowrap/dist/objects";
+import {DataSource} from "typeorm";
+import {Logger} from "winston";
+import {ExtendedSnoowrap} from "../../Utils/SnoowrapClients";
+import {ManagerEntity} from "../Entities/ManagerEntity";
+import {Bot} from "../Entities/Bot";
+import {EventRetentionPolicyRange, StatisticFrequencyOption} from "../Infrastructure/Atomic";
+
+export interface SubredditResourceOptions extends Footer {
+    ttl: Required<TTLConfig>
+    cache: Cache
+    cacheType: string;
+    cacheSettingsHash: string
+    subreddit: Subreddit,
+    database: DataSource
+    logger: Logger;
+    client: ExtendedSnoowrap;
+    prefix?: string;
+    actionedEventsMax: number;
+    thirdPartyCredentials: ThirdPartyCredentialsJsonConfig
+    delayedItems?: ActivityDispatch[]
+    botAccount?: string
+    botName: string
+    managerEntity: ManagerEntity
+    botEntity: Bot
+    statFrequency: StatisticFrequencyOption
+    retention?: EventRetentionPolicyRange
+}
+
+export interface SubredditResourceConfig extends Footer {
+    caching?: CacheConfig,
+    subreddit: Subreddit,
+    logger: Logger;
+    client: ExtendedSnoowrap
+    credentials?: ThirdPartyCredentialsJsonConfig
+    managerEntity: ManagerEntity
+    botEntity: Bot
+    statFrequency: StatisticFrequencyOption
+    retention?: EventRetentionPolicyRange
+}

--- a/src/Common/interfaces.ts
+++ b/src/Common/interfaces.ts
@@ -791,6 +791,11 @@ export interface CacheOptions {
      * */
     max?: number
 
+    /**
+     * A prefix to add to all keys
+     * */
+    prefix?: string
+
     [key:string]: any
 }
 

--- a/src/Common/interfaces.ts
+++ b/src/Common/interfaces.ts
@@ -481,6 +481,8 @@ export interface TTLConfig {
     modNotesTTL?: number | boolean;
 }
 
+export type StrongTTLConfig = Record<keyof TTLConfig, number | false>;
+
 export interface CacheConfig extends TTLConfig {
     /**
      * The cache provider and, optionally, a custom configuration for that provider

--- a/src/Common/interfaces.ts
+++ b/src/Common/interfaces.ts
@@ -651,6 +651,33 @@ export interface ManagerOptions {
      *
      * */
     retention?: EventRetentionPolicyRange
+
+    /**
+     * Enables config sharing
+     *
+     * * (Default) When `false` sharing is not enabled
+     * * When `true` any bot that can access this bot's config wiki page can use inpm t
+     * * When an object, use `include` or `exclude` to define subreddits that can access this config
+     * */
+    sharing?: boolean | string[] | SharingACLConfig
+}
+
+export interface SharingACLConfig {
+    /**
+     * A list of subreddits, or regular expressions for subreddit names, that are allowed to access this config
+     * */
+    include?: string[]
+    /**
+     * A list of subreddits, or regular expressions for subreddit names, that are NOT allowed to access this config
+     *
+     * If `include` is defined this property is ignored
+     * */
+    exclude?: string[]
+}
+
+export interface StrongSharingACLConfig {
+    include?: RegExp[]
+    exclude?: RegExp[]
 }
 
 export interface ThresholdCriteria {

--- a/src/Common/interfaces.ts
+++ b/src/Common/interfaces.ts
@@ -481,7 +481,7 @@ export interface TTLConfig {
     modNotesTTL?: number | boolean;
 }
 
-export type StrongTTLConfig = Record<keyof TTLConfig, number | false>;
+export type StrongTTLConfig = Record<keyof Required<TTLConfig>, number | false>;
 
 export interface CacheConfig extends TTLConfig {
     /**
@@ -492,32 +492,9 @@ export interface CacheConfig extends TTLConfig {
      * To specify another `provider` but use its default configuration set this property to a string of one of the available providers: `memory`, `redis`, or `none`
      * */
     provider?: CacheProvider | CacheOptions
-
-    /**
-     * The **maximum** number of Events that the cache should store triggered result summaries for
-     *
-     * These summaries are viewable through the Web UI.
-     *
-     * The value specified by a subreddit cannot be larger than the value set by the Operator for the global/bot config (if set)
-     *
-     * @default 25
-     * @example [25]
-     * */
-    actionedEventsMax?: number
 }
 
 export interface OperatorCacheConfig extends CacheConfig {
-    /**
-     * The **default** number of Events that the cache will store triggered result summaries for
-     *
-     * These summaries are viewable through the Web UI.
-     *
-     * The value specified cannot be larger than `actionedEventsMax` for the global/bot config (if set)
-     *
-     * @default 25
-     * @example [25]
-     * */
-    actionedEventsDefault?: number
 }
 
 export interface Footer {
@@ -755,8 +732,6 @@ export type StrongCache = {
     modNotesTTL: number | boolean,
     filterCriteriaTTL: number | boolean,
     provider: CacheOptions
-    actionedEventsMax?: number,
-    actionedEventsDefault: number,
 }
 
 /**

--- a/src/ConfigBuilder.ts
+++ b/src/ConfigBuilder.ts
@@ -364,12 +364,14 @@ export class ConfigBuilder {
         return validatedHydratedConfig;
     }
 
-    async parseToStructured(config: SubredditConfigData, resource: SubredditResources, filterCriteriaDefaultsFromBot?: FilterCriteriaDefaults, postCheckBehaviorDefaultsFromBot: PostBehavior = {}): Promise<RunConfigObject[]> {
+    async parseToHydrated(config: SubredditConfigData, resource: SubredditResources) {
+        return await this.hydrateConfig(config, resource);
+    }
+
+    async parseToStructured(hydratedConfig: SubredditConfigHydratedData, resource: SubredditResources, filterCriteriaDefaultsFromBot?: FilterCriteriaDefaults, postCheckBehaviorDefaultsFromBot: PostBehavior = {}): Promise<RunConfigObject[]> {
         let namedRules: Map<string, RuleConfigObject> = new Map();
         let namedActions: Map<string, ActionConfigObject> = new Map();
-        const {filterCriteriaDefaults, postCheckBehaviorDefaults} = config;
-
-        const hydratedConfig = await this.hydrateConfig(config, resource);
+        const {filterCriteriaDefaults, postCheckBehaviorDefaults} = hydratedConfig;
 
         const {runs: realRuns = []} = hydratedConfig;
 

--- a/src/ConfigBuilder.ts
+++ b/src/ConfigBuilder.ts
@@ -1247,8 +1247,6 @@ export const buildOperatorConfigWithDefaults = async (data: OperatorJsonConfig):
 
     let cache: StrongCache;
     let defaultProvider: CacheOptions;
-    let opActionedEventsMax: number | undefined;
-    let opActionedEventsDefault: number = 25;
 
     const dataDir = process.env.DATA_DIR ?? defaultDataDir;
 
@@ -1260,16 +1258,10 @@ export const buildOperatorConfigWithDefaults = async (data: OperatorJsonConfig):
         cache = {
             ...cacheTTLDefaults,
             provider: defaultProvider,
-            actionedEventsDefault: opActionedEventsDefault,
         };
 
     } else {
-        const {provider, actionedEventsMax, actionedEventsDefault = opActionedEventsDefault, ...restConfig} = opCache;
-
-        if (actionedEventsMax !== undefined && actionedEventsMax !== null) {
-            opActionedEventsMax = actionedEventsMax;
-            opActionedEventsDefault = Math.min(actionedEventsDefault, actionedEventsMax);
-        }
+        const {provider, ...restConfig} = opCache;
 
         if (typeof provider === 'string') {
             defaultProvider = {
@@ -1287,8 +1279,6 @@ export const buildOperatorConfigWithDefaults = async (data: OperatorJsonConfig):
         cache = {
             ...cacheTTLDefaults,
             ...restConfig,
-            actionedEventsMax: opActionedEventsMax,
-            actionedEventsDefault: opActionedEventsDefault,
             provider: defaultProvider,
         }
     }
@@ -1427,8 +1417,6 @@ export const buildBotConfig = (data: BotInstanceJsonConfig, opConfig: OperatorCo
     const {
         snoowrap: snoowrapOp,
         caching: {
-            actionedEventsMax: opActionedEventsMax,
-            actionedEventsDefault: opActionedEventsDefault = 25,
             provider: defaultProvider,
         } = {},
         userAgent,
@@ -1483,28 +1471,18 @@ export const buildBotConfig = (data: BotInstanceJsonConfig, opConfig: OperatorCo
 
         botCache = {
             ...cacheTTLDefaults,
-            actionedEventsDefault: opActionedEventsDefault,
-            actionedEventsMax: opActionedEventsMax,
             provider: {...defaultProvider as CacheOptions}
         };
     } else {
         const {
             provider,
-            actionedEventsMax = opActionedEventsMax,
-            actionedEventsDefault = opActionedEventsDefault,
             ...restConfig
         } = caching;
-
-        botActionedEventsDefault = actionedEventsDefault;
-        if (actionedEventsMax !== undefined) {
-            botActionedEventsDefault = Math.min(actionedEventsDefault, actionedEventsMax);
-        }
 
         if (typeof provider === 'string') {
             botCache = {
                 ...cacheTTLDefaults,
                 ...restConfig,
-                actionedEventsDefault: botActionedEventsDefault,
                 provider: {
                     store: provider as CacheProvider,
                     ...cacheOptDefaults
@@ -1515,8 +1493,6 @@ export const buildBotConfig = (data: BotInstanceJsonConfig, opConfig: OperatorCo
             botCache = {
                 ...cacheTTLDefaults,
                 ...restConfig,
-                actionedEventsDefault: botActionedEventsDefault,
-                actionedEventsMax,
                 provider: {
                     store,
                     ...cacheOptDefaults,

--- a/src/Rule/MHSRule.ts
+++ b/src/Rule/MHSRule.ts
@@ -229,7 +229,7 @@ export class MHSRule extends Rule {
     protected async getMHSResponse(content: string): Promise<MHSResponse> {
         const hash = objectHash.sha1({content});
         const key = `mhs-${hash}`;
-        if (this.resources.wikiTTL !== false) {
+        if (this.resources.ttl.wikiTTL !== false) {
             let res = await this.resources.cache.get(key) as undefined | null | MHSResponse;
             if(res !== undefined && res !== null) {
                 // don't cache bad responses
@@ -240,7 +240,7 @@ export class MHSRule extends Rule {
             }
             res = await this.callMHS(content);
             if(res.response.toLowerCase() === 'success') {
-                await this.resources.cache.set(key, res, {ttl: this.resources.wikiTTL});
+                await this.resources.cache.set(key, res, {ttl: this.resources.ttl.wikiTTL});
             }
             return res;
         }

--- a/src/Schema/App.json
+++ b/src/Schema/App.json
@@ -1023,11 +1023,6 @@
         },
         "CacheConfig": {
             "properties": {
-                "actionedEventsMax": {
-                    "default": 25,
-                    "description": "The **maximum** number of Events that the cache should store triggered result summaries for\n\nThese summaries are viewable through the Web UI.\n\nThe value specified by a subreddit cannot be larger than the value set by the Operator for the global/bot config (if set)",
-                    "type": "number"
-                },
                 "authorTTL": {
                     "default": 60,
                     "description": "Amount of time, in seconds, author activity history (Comments/Submission) should be cached\n\n* If `0` or `true` will cache indefinitely (not recommended)\n* If `false` will not cache\n\n* ENV => `AUTHOR_TTL`\n* ARG => `--authorTTL <sec>`",

--- a/src/Schema/App.json
+++ b/src/Schema/App.json
@@ -5945,6 +5945,25 @@
             ],
             "type": "object"
         },
+        "SharingACLConfig": {
+            "properties": {
+                "exclude": {
+                    "description": "A list of subreddits, or regular expressions for subreddit names, that are NOT allowed to access this config\n\nIf `include` is defined this property is ignored",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "include": {
+                    "description": "A list of subreddits, or regular expressions for subreddit names, that are allowed to access this config",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        },
         "SubmissionActionJson": {
             "description": "Reply to the Activity. For a submission the reply will be a top-level comment.",
             "properties": {
@@ -7160,6 +7179,23 @@
             },
             "minItems": 1,
             "type": "array"
+        },
+        "sharing": {
+            "anyOf": [
+                {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                {
+                    "$ref": "#/definitions/SharingACLConfig"
+                },
+                {
+                    "type": "boolean"
+                }
+            ],
+            "description": "Enables config sharing\n\n* (Default) When `false` sharing is not enabled\n* When `true` any bot that can access this bot's config wiki page can use inpm t\n* When an object, use `include` or `exclude` to define subreddits that can access this config"
         }
     },
     "type": "object"

--- a/src/Schema/App.json
+++ b/src/Schema/App.json
@@ -1181,6 +1181,10 @@
                     ],
                     "type": "number"
                 },
+                "prefix": {
+                    "description": "A prefix to add to all keys",
+                    "type": "string"
+                },
                 "store": {
                     "$ref": "#/definitions/CacheProvider"
                 },

--- a/src/Schema/OperatorConfig.json
+++ b/src/Schema/OperatorConfig.json
@@ -968,8 +968,18 @@
                 "credentials": {
                     "$ref": "#/definitions/InfluxCredentials"
                 },
+                "debug": {
+                    "type": "boolean"
+                },
                 "defaultTags": {
                     "$ref": "#/definitions/Record<string,string>"
+                },
+                "useKeepAliveAgent": {
+                    "type": "boolean"
+                },
+                "writeOptions": {
+                    "$ref": "#/definitions/WriteOptions",
+                    "description": "Options used by{@linkWriteApi}."
                 }
             },
             "required": [
@@ -1571,16 +1581,6 @@
         },
         "OperatorCacheConfig": {
             "properties": {
-                "actionedEventsDefault": {
-                    "default": 25,
-                    "description": "The **default** number of Events that the cache will store triggered result summaries for\n\nThese summaries are viewable through the Web UI.\n\nThe value specified cannot be larger than `actionedEventsMax` for the global/bot config (if set)",
-                    "type": "number"
-                },
-                "actionedEventsMax": {
-                    "default": 25,
-                    "description": "The **maximum** number of Events that the cache should store triggered result summaries for\n\nThese summaries are viewable through the Web UI.\n\nThe value specified by a subreddit cannot be larger than the value set by the Operator for the global/bot config (if set)",
-                    "type": "number"
-                },
                 "authorTTL": {
                     "default": 60,
                     "description": "Amount of time, in seconds, author activity history (Comments/Submission) should be cached\n\n* If `0` or `true` will cache indefinitely (not recommended)\n* If `false` will not cache\n\n* ENV => `AUTHOR_TTL`\n* ARG => `--authorTTL <sec>`",
@@ -2341,6 +2341,94 @@
                     "type": "string"
                 }
             },
+            "type": "object"
+        },
+        "WriteOptions": {
+            "description": "Options used by{@linkWriteApi}.",
+            "properties": {
+                "batchSize": {
+                    "description": "max number of records/lines to send in a batch",
+                    "type": "number"
+                },
+                "consistency": {
+                    "description": "InfluxDB Enterprise write consistency as explained in https://docs.influxdata.com/enterprise_influxdb/v1.9/concepts/clustering/#write-consistency",
+                    "enum": [
+                        "all",
+                        "any",
+                        "one",
+                        "quorum"
+                    ],
+                    "type": "string"
+                },
+                "defaultTags": {
+                    "$ref": "#/definitions/Record<string,string>",
+                    "description": "default tags, unescaped"
+                },
+                "exponentialBase": {
+                    "description": "base for the exponential retry delay",
+                    "type": "number"
+                },
+                "flushInterval": {
+                    "description": "delay between data flushes in milliseconds, at most `batch size` records are sent during flush",
+                    "type": "number"
+                },
+                "gzipThreshold": {
+                    "description": "When specified, write bodies larger than the threshold are gzipped",
+                    "type": "number"
+                },
+                "headers": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "HTTP headers that will be sent with every write request",
+                    "type": "object"
+                },
+                "maxBatchBytes": {
+                    "description": "max size of a batch in bytes",
+                    "type": "number"
+                },
+                "maxBufferLines": {
+                    "description": "the maximum size of retry-buffer (in lines)",
+                    "type": "number"
+                },
+                "maxRetries": {
+                    "description": "max count of retries after the first write fails",
+                    "type": "number"
+                },
+                "maxRetryDelay": {
+                    "description": "maximum delay when retrying write (milliseconds)",
+                    "type": "number"
+                },
+                "maxRetryTime": {
+                    "description": "max time (millis) that can be spent with retries",
+                    "type": "number"
+                },
+                "minRetryDelay": {
+                    "description": "minimum delay when retrying write (milliseconds)",
+                    "type": "number"
+                },
+                "randomRetry": {
+                    "description": "randomRetry indicates whether the next retry delay is deterministic (false) or random (true).\nThe deterministic delay starts with `minRetryDelay * exponentialBase` and it is multiplied\nby `exponentialBase` until it exceeds `maxRetryDelay`.\nWhen random is `true`, the next delay is computed as a random number between next retry attempt (upper)\nand the lower number in the deterministic sequence. `random(retryJitter)` is added to every returned value.",
+                    "type": "boolean"
+                },
+                "retryJitter": {
+                    "description": "add `random(retryJitter)` milliseconds delay when retrying HTTP calls",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "batchSize",
+                "exponentialBase",
+                "flushInterval",
+                "maxBatchBytes",
+                "maxBufferLines",
+                "maxRetries",
+                "maxRetryDelay",
+                "maxRetryTime",
+                "minRetryDelay",
+                "randomRetry",
+                "retryJitter"
+            ],
             "type": "object"
         }
     },

--- a/src/Schema/OperatorConfig.json
+++ b/src/Schema/OperatorConfig.json
@@ -474,6 +474,10 @@
                     ],
                     "type": "number"
                 },
+                "prefix": {
+                    "description": "A prefix to add to all keys",
+                    "type": "string"
+                },
                 "store": {
                     "$ref": "#/definitions/CacheProvider"
                 },

--- a/src/Subreddit/Manager.ts
+++ b/src/Subreddit/Manager.ts
@@ -973,7 +973,7 @@ export class Manager extends EventEmitter implements RunningStates {
         const itemId = await item.id;
 
         if(await this.resources.hasRecentSelf(item)) {
-            let recentMsg = `Found in Activities recently (last ${this.resources.selfTTL} seconds) modified/created by this bot`;
+            let recentMsg = `Found in Activities recently (last ${this.resources.ttl.selfTTL} seconds) modified/created by this bot`;
             if(force) {
                 this.logger.debug(`${recentMsg} but will run anyway because "force" option was true.`);
             } else {

--- a/src/Subreddit/Manager.ts
+++ b/src/Subreddit/Manager.ts
@@ -53,10 +53,7 @@ import {Submission, Comment, Subreddit} from 'snoowrap/dist/objects';
 import {activityIsRemoved, ItemContent, itemContentPeek} from "../Utils/SnoowrapUtils";
 import LoggedError from "../Utils/LoggedError";
 import {
-    BotResourcesManager,
-    SubredditResourceConfig,
-    SubredditResources,
-    SubredditResourceSetOptions
+    SubredditResources
 } from "./SubredditResources";
 import {SPoll, UnmoderatedStream, ModQueueStream, SubmissionStream, CommentStream} from "./Streams";
 import EventEmitter from "events";
@@ -107,6 +104,8 @@ import {InfluxClient} from "../Common/Influx/InfluxClient";
 import { Point } from "@influxdata/influxdb-client";
 import {NormalizedManagerResponse} from "../Web/Common/interfaces";
 import {guestEntityToApiGuest} from "../Common/Entities/Guest/GuestEntity";
+import {BotResourcesManager} from "../Bot/ResourcesManager";
+import {SubredditResourceConfig} from "../Common/Subreddit/SubredditResourceInterfaces";
 
 export interface RunningState {
     state: RunState,

--- a/src/Subreddit/Manager.ts
+++ b/src/Subreddit/Manager.ts
@@ -272,8 +272,8 @@ export class Manager extends EventEmitter implements RunningStates {
             data.historical = this.resources.getHistoricalDisplayStats();
             data.cache = resStats.cache;
             data.cache.currentKeyCount = await this.resources.getCacheKeyCount();
-            data.cache.isShared = this.resources.cacheSettingsHash === 'default';
-            data.cache.provider = this.resources.cacheType;
+            data.cache.isShared = this.resources.cache.isDefaultCache;
+            data.cache.provider = this.resources.cache.providerOptions.store;
         }
         return data;
     }

--- a/src/Subreddit/Manager.ts
+++ b/src/Subreddit/Manager.ts
@@ -380,7 +380,7 @@ export class Manager extends EventEmitter implements RunningStates {
 
         this.eventsSampleInterval = setInterval((function(self) {
             return function() {
-                const et = self.resources !== undefined ? self.resources.stats.historical.eventsCheckedTotal : 0;
+                const et = self.resources !== undefined ? self.resources.subredditStats.stats.historical.eventsCheckedTotal : 0;
                 const rollingSample = self.eventsSample.slice(0, 7)
                 rollingSample.unshift(et)
                 self.eventsSample = rollingSample;
@@ -402,7 +402,7 @@ export class Manager extends EventEmitter implements RunningStates {
         this.rulesUniqueSampleInterval = setInterval((function(self) {
             return function() {
                 const rollingSample = self.rulesUniqueSample.slice(0, 7)
-                const rt = self.resources !== undefined ? self.resources.stats.historical.rulesRunTotal - self.resources.stats.historical.rulesCachedTotal : 0;
+                const rt = self.resources !== undefined ? self.resources.subredditStats.stats.historical.rulesRunTotal - self.resources.subredditStats.stats.historical.rulesCachedTotal : 0;
                 rollingSample.unshift(rt);
                 self.rulesUniqueSample = rollingSample;
                 const diff = self.rulesUniqueSample.reduceRight((acc: number[], curr, index) => {

--- a/src/Subreddit/Manager.ts
+++ b/src/Subreddit/Manager.ts
@@ -106,6 +106,7 @@ import {NormalizedManagerResponse} from "../Web/Common/interfaces";
 import {guestEntityToApiGuest} from "../Common/Entities/Guest/GuestEntity";
 import {BotResourcesManager} from "../Bot/ResourcesManager";
 import {SubredditResourceConfig} from "../Common/Subreddit/SubredditResourceInterfaces";
+import objectHash from "object-hash";
 
 export interface RunningState {
     state: RunState,
@@ -209,6 +210,7 @@ export class Manager extends EventEmitter implements RunningStates {
 
     startedAt?: DayjsObj;
     validConfigLoaded: boolean = false;
+    lastParseConfigHash?: string;
 
     eventsState: RunningState = {
         state: STOPPED,
@@ -699,7 +701,9 @@ export class Manager extends EventEmitter implements RunningStates {
             this.logger.info('Subreddit-specific options updated');
             this.logger.info('Building Runs and Checks...');
 
-            const structuredRuns = await configBuilder.parseToStructured(validJson, this.resources, this.filterCriteriaDefaults, this.postCheckBehaviorDefaults);
+            const hydratedConfig = await configBuilder.hydrateConfig(validJson, this.resources);
+            this.lastParseConfigHash = objectHash.sha1(hydratedConfig);
+            const structuredRuns = await configBuilder.parseToStructured(hydratedConfig, this.resources, this.filterCriteriaDefaults, this.postCheckBehaviorDefaults);
 
             let runs: Run[] = [];
 
@@ -809,6 +813,7 @@ export class Manager extends EventEmitter implements RunningStates {
         }
         //this.wikiUpdateRunning = true;
         this.lastWikiCheck = dayjs();
+        let wikiPageChanged = false;
 
         try {
             let sourceData: string;
@@ -831,26 +836,16 @@ export class Manager extends EventEmitter implements RunningStates {
                     }
                 }
                 const revisionDate = dayjs.unix(wiki.revision_date);
-                if (!force && this.validConfigLoaded && (this.lastWikiRevision !== undefined && this.lastWikiRevision.isSame(revisionDate))) {
-                    // nothing to do, we already have this revision
-                    //this.wikiUpdateRunning = false;
-                    if (force) {
-                        this.logger.info('Config is up to date');
+
+                if(this.lastWikiRevision !== undefined) {
+                    if(this.lastWikiRevision.isSame(revisionDate)) {
+                        this.logger.verbose('Config wiki has not changed since last check, going ahead with other checks...');
+                    } else {
+                        wikiPageChanged = true;
+                        this.logger.info(`Updating config due to stale wiki page (${dayjs.duration(dayjs().diff(revisionDate)).humanize()} old)`)
                     }
-                    return false;
-                }
-
-                if (force) {
-                    this.logger.info('Config update was forced');
-                } else if (!this.validConfigLoaded) {
+                } else {
                     this.logger.info('Trying to load (new?) config now since there is no valid config loaded');
-                } else if (this.lastWikiRevision !== undefined) {
-                    this.logger.info(`Updating config due to stale wiki page (${dayjs.duration(dayjs().diff(revisionDate)).humanize()} old)`)
-                }
-
-                if(this.queueState.state === RUNNING) {
-                    this.logger.verbose('Waiting for activity processing queue to pause before continuing config update');
-                    await this.pauseQueue(causedBy);
                 }
 
                 this.lastWikiRevision = revisionDate;
@@ -860,8 +855,8 @@ export class Manager extends EventEmitter implements RunningStates {
             }
 
             if (sourceData.replace('\r\n', '').trim() === '') {
-                this.logger.error(`Wiki page contents was empty`);
-                throw new ConfigParseError('Wiki page contents was empty');
+                this.logger.error(`Wiki page contents is empty. The bot cannot run until this subreddit's wiki page has a valid config added!`);
+                throw new ConfigParseError(`Wiki page contents is empty. The bot cannot run until this subreddit's wiki page has a valid config added!`);
             }
 
             const [format, configObj, jsonErr, yamlErr] = parseFromJsonOrYamlToObject(sourceData);
@@ -881,6 +876,23 @@ export class Manager extends EventEmitter implements RunningStates {
                 throw new ConfigParseError('Could not parse wiki page contents as JSON or YAML')
             }
 
+            if (!wikiPageChanged && this.validConfigLoaded && this.lastParseConfigHash !== undefined && !force) {
+                // need to check if hydrated is different from current
+                const hydratedRuns = await this.buildHydratedRuns(configObj.toJS());
+                const hydratedHash = objectHash.sha1(hydratedRuns);
+                if (hydratedHash === this.lastParseConfigHash) {
+                    this.logger.info('Config is up to date');
+                    return false;
+                } else {
+                    this.logger.info('Hydrated config differed from wiki contents, continuing with update.');
+                }
+            }
+
+            if(this.queueState.state === RUNNING) {
+                this.logger.verbose('Waiting for activity processing queue to pause before continuing config update');
+                await this.pauseQueue(causedBy);
+            }
+
             await this.parseConfigurationFromObject(configObj.toJS(), suppressChangeEvent);
             this.logger.info('Checks updated');
 
@@ -898,6 +910,12 @@ export class Manager extends EventEmitter implements RunningStates {
             this.validConfigLoaded = false;
             throw new ErrorWithCause('Failed to parse subreddit configuration', {cause: err});
         }
+    }
+
+    async buildHydratedRuns(configObj: object) {
+        const configBuilder = new ConfigBuilder({logger: this.logger});
+        const validJson = configBuilder.validateJson(configObj);
+        return await configBuilder.hydrateConfig(validJson, this.resources);
     }
 
     async handleActivity(activity: (Submission | Comment), options: runCheckOptions): Promise<void> {

--- a/src/Subreddit/Stats/index.ts
+++ b/src/Subreddit/Stats/index.ts
@@ -1,0 +1,277 @@
+import {Between, DataSource, Repository} from "typeorm";
+import {TotalStat} from "../../Common/Entities/Stats/TotalStat";
+import {TimeSeriesStat} from "../../Common/Entities/Stats/TimeSeriesStat";
+import {statFrequencies, StatisticFrequencyOption} from "../../Common/Infrastructure/Atomic";
+import {ManagerEntity} from "../../Common/Entities/ManagerEntity";
+import {HistoricalStatsDisplay, ResourceStats} from "../../Common/interfaces";
+import {createHistoricalDisplayDefaults} from "../../Common/defaults";
+import dayjs from "dayjs";
+import {ErrorWithCause} from "pony-cause";
+import {cacheStats, formatNumber, frequencyEqualOrLargerThanMin, mergeArr} from "../../util";
+import {Cache} from "cache-manager";
+import winston, {Logger} from "winston";
+
+export class SubredditStats {
+    totalStatsRepo: Repository<TotalStat>
+    totalStatsEntities?: TotalStat[];
+    tsStatsRepo: Repository<TimeSeriesStat>
+    timeSeriesStatsEntities?: TimeSeriesStat[];
+    statFrequency: StatisticFrequencyOption
+    historicalSaveInterval?: any;
+    managerEntity: ManagerEntity;
+    cache: Cache;
+    protected logger: Logger;
+
+    stats: {
+        cache: ResourceStats
+        historical: HistoricalStatsDisplay
+        timeSeries: HistoricalStatsDisplay
+    };
+
+    constructor(database: DataSource, managerEntity: ManagerEntity, cache: Cache, statFrequency: StatisticFrequencyOption, logger: Logger) {
+        this.totalStatsRepo = database.getRepository(TotalStat);
+        this.tsStatsRepo = database.getRepository(TimeSeriesStat);
+        this.statFrequency = statFrequency;
+        this.managerEntity = managerEntity;
+        this.cache = cache;
+        if (logger === undefined) {
+            const alogger = winston.loggers.get('app')
+            this.logger = alogger.child({labels: [this.managerEntity.name, 'Stats']}, mergeArr);
+        } else {
+            this.logger = logger.child({labels: ['Stats']}, mergeArr);
+        }
+
+        this.stats = {
+            cache: cacheStats(),
+            historical: createHistoricalDisplayDefaults(),
+            timeSeries: createHistoricalDisplayDefaults(),
+        };
+    }
+
+    async initStats() {
+        try {
+            let currentStats: HistoricalStatsDisplay = createHistoricalDisplayDefaults();
+            const totalStats = await this.totalStatsRepo.findBy({managerId: this.managerEntity.id});
+            if (totalStats.length === 0) {
+                const now = dayjs();
+                const statEntities: TotalStat[] = [];
+                for (const [k, v] of Object.entries(currentStats)) {
+                    statEntities.push(new TotalStat({
+                        metric: k,
+                        value: v,
+                        manager: this.managerEntity,
+                        createdAt: now,
+                    }));
+                }
+                await this.totalStatsRepo.save(statEntities);
+                this.totalStatsEntities = statEntities;
+            } else {
+                this.totalStatsEntities = totalStats;
+                for (const [k, v] of Object.entries(currentStats)) {
+                    const matchedStat = totalStats.find(x => x.metric === k);
+                    if (matchedStat !== undefined) {
+                        currentStats[k] = matchedStat.value;
+                    } else {
+                        this.logger.warn(`Could not find historical stat matching '${k}' in the database, will default to 0`);
+                        currentStats[k] = v;
+                    }
+                }
+            }
+            this.stats.historical = currentStats;
+        } catch (e) {
+            this.logger.error(new ErrorWithCause('Failed to init historical stats', {cause: e}));
+        }
+
+        try {
+            if (this.statFrequency !== false) {
+                let currentStats: HistoricalStatsDisplay = createHistoricalDisplayDefaults();
+                let startRange = dayjs().set('second', 0);
+                for (const unit of statFrequencies) {
+                    if (unit !== 'week' && !frequencyEqualOrLargerThanMin(unit, this.statFrequency)) {
+                        startRange = startRange.set(unit, 0);
+                    }
+                    if (unit === 'week' && this.statFrequency === 'week') {
+                        // make sure we get beginning of week
+                        startRange = startRange.week(startRange.week());
+                    }
+                }
+                // set end range by +1 of whatever unit we are using
+                const endRange = this.statFrequency === 'week' ? startRange.clone().week(startRange.week() + 1) : startRange.clone().set(this.statFrequency, startRange.get(this.statFrequency) + 1);
+
+                const tsStats = await this.tsStatsRepo.findBy({
+                    managerId: this.managerEntity.id,
+                    granularity: this.statFrequency,
+                    // make sure its inclusive!
+                    _createdAt: Between(startRange.clone().subtract(1, 'second').toDate(), endRange.clone().add(1, 'second').toDate())
+                });
+
+                if (tsStats.length === 0) {
+                    const statEntities: TimeSeriesStat[] = [];
+                    for (const [k, v] of Object.entries(currentStats)) {
+                        statEntities.push(new TimeSeriesStat({
+                            metric: k,
+                            value: v,
+                            granularity: this.statFrequency,
+                            manager: this.managerEntity,
+                            createdAt: startRange,
+                        }));
+                    }
+                    this.timeSeriesStatsEntities = statEntities;
+                } else {
+                    this.timeSeriesStatsEntities = tsStats;
+                }
+
+                for (const [k, v] of Object.entries(currentStats)) {
+                    const matchedStat = this.timeSeriesStatsEntities.find(x => x.metric === k);
+                    if (matchedStat !== undefined) {
+                        currentStats[k] = matchedStat.value;
+                    } else {
+                        this.logger.warn(`Could not find time series stat matching '${k}' in the database, will default to 0`);
+                        currentStats[k] = v;
+                    }
+                }
+            }
+        } catch (e) {
+            this.logger.error(new ErrorWithCause('Failed to init frequency (time series) stats', {cause: e}));
+        }
+    }
+
+    updateHistoricalStats(data: Partial<HistoricalStatsDisplay>) {
+        for (const [k, v] of Object.entries(data)) {
+            if (this.stats.historical[k] !== undefined && v !== undefined) {
+                this.stats.historical[k] += v;
+            }
+            if (this.stats.timeSeries[k] !== undefined && v !== undefined) {
+                this.stats.timeSeries[k] += v;
+            }
+        }
+    }
+
+    getHistoricalDisplayStats(): HistoricalStatsDisplay {
+        return this.stats.historical;
+    }
+
+    async saveHistoricalStats() {
+        if (this.totalStatsEntities !== undefined) {
+            for (const [k, v] of Object.entries(this.stats.historical)) {
+                const matchedStatIndex = this.totalStatsEntities.findIndex(x => x.metric === k);
+                if (matchedStatIndex !== -1) {
+                    this.totalStatsEntities[matchedStatIndex].value = v;
+                } else {
+                    this.logger.warn(`Could not find historical stat matching '${k}' in total stats??`);
+                }
+
+            }
+            await this.totalStatsRepo.save(this.totalStatsEntities);
+        }
+
+        if (this.timeSeriesStatsEntities !== undefined) {
+            for (const [k, v] of Object.entries(this.stats.timeSeries)) {
+                const matchedStatIndex = this.timeSeriesStatsEntities.findIndex(x => x.metric === k);
+                if (matchedStatIndex !== -1) {
+                    this.timeSeriesStatsEntities[matchedStatIndex].value = v;
+                } else {
+                    this.logger.warn(`Could not find time series stat matching '${k}' in total stats??`);
+                }
+
+            }
+            await this.tsStatsRepo.save(this.timeSeriesStatsEntities);
+        }
+    }
+
+    setHistoricalSaveInterval() {
+        this.historicalSaveInterval = setInterval((function (self) {
+            return async () => {
+                await self.saveHistoricalStats();
+            }
+        })(this), 10000);
+    }
+
+    getCacheTotals() {
+        return Object.values(this.stats.cache).reduce((acc, curr) => ({
+            miss: acc.miss + curr.miss,
+            req: acc.req + curr.requests,
+        }), {miss: 0, req: 0});
+    }
+
+    getCacheStats() {
+        return this.stats.cache;
+    }
+
+    async getCacheStatsForManager() {
+        const totals = this.getCacheTotals();
+        const cacheKeys = Object.keys(this.stats.cache);
+        const res = {
+            cache: {
+                // TODO could probably combine these two
+                totalRequests: totals.req,
+                totalMiss: totals.miss,
+                missPercent: `${formatNumber(totals.miss === 0 || totals.req === 0 ? 0 :(totals.miss/totals.req) * 100, {toFixed: 0})}%`,
+                types: await cacheKeys.reduce(async (accProm, curr) => {
+                    const acc = await accProm;
+                    // calculate miss percent
+
+                    const per = acc[curr].miss === 0 ? 0 : formatNumber(acc[curr].miss / acc[curr].requests) * 100;
+                    acc[curr].missPercent = `${formatNumber(per, {toFixed: 0})}%`;
+
+                    // calculate average identifier hits
+
+                    const idCache = acc[curr].identifierRequestCount;
+                    // @ts-expect-error
+                    const idKeys = await idCache.store.keys() as string[];
+                    if(idKeys.length > 0) {
+                        let hits = 0;
+                        for (const k of idKeys) {
+                            hits += await idCache.get(k) as number;
+                        }
+                        acc[curr].identifierAverageHit = formatNumber(hits/idKeys.length);
+                    }
+
+                    if(acc[curr].requestTimestamps.length > 1) {
+                        // calculate average time between request
+                        const diffData = acc[curr].requestTimestamps.reduce((accTimestampData, curr: number) => {
+                            if(accTimestampData.last === 0) {
+                                accTimestampData.last = curr;
+                                return accTimestampData;
+                            }
+                            accTimestampData.diffs.push(curr - accTimestampData.last);
+                            accTimestampData.last = curr;
+                            return accTimestampData;
+                        },{last: 0, diffs: [] as number[]});
+                        const avgDiff = diffData.diffs.reduce((acc, curr) => acc + curr, 0) / diffData.diffs.length;
+
+                        acc[curr].averageTimeBetweenHits = formatNumber(avgDiff/1000);
+                    }
+
+                    const {requestTimestamps, identifierRequestCount, ...rest} = acc[curr];
+                    // @ts-ignore
+                    acc[curr] = rest;
+
+                    return acc;
+                }, Promise.resolve({...this.stats.cache}))
+            }
+        }
+        return res;
+    }
+
+    async incrementCacheTypeStat(cacheType: keyof ResourceStats, hash?: string, miss?: boolean) {
+        if (this.stats.cache[cacheType] === undefined) {
+            this.logger.warn(`Cache type ${cacheType} does not exist. Fix this!`);
+        }
+        if(hash !== undefined) {
+            await this.stats.cache[cacheType].identifierRequestCount.set(hash, (await this.stats.cache[cacheType].identifierRequestCount.wrap(hash, () => 0) as number) + 1);
+        }
+        this.stats.cache[cacheType].requestTimestamps.push(Date.now());
+        this.stats.cache[cacheType].requests++;
+
+        if (miss === true) {
+            this.stats.cache[cacheType].miss++;
+        }
+    }
+
+    async destroy() {
+        if (this.historicalSaveInterval !== undefined) {
+            clearInterval(this.historicalSaveInterval);
+        }
+    }
+}

--- a/src/Subreddit/SubredditResources.ts
+++ b/src/Subreddit/SubredditResources.ts
@@ -1785,7 +1785,7 @@ export class SubredditResources {
         return this.renderContent(footer, item);
     }
 
-    async getConfigFragment<T>(includesData: IncludesData, validateFunc?: ConfigFragmentValidationFunc): Promise<T> {
+    async getConfigFragment<T>(includesData: IncludesData, validateFunc?: ConfigFragmentParseFunc): Promise<T> {
 
         const {
             path,
@@ -1813,8 +1813,7 @@ export class SubredditResources {
         // otherwise now we want to validate it if a function is present
         if(validateFunc !== undefined) {
             try {
-               validateFunc(configObj.toJS(), fromCache);
-               validatedData = rawData as unknown as T;
+                validatedData = validateFunc(configObj.toJS(), fromCache) as unknown as T;
             } catch (e) {
                 throw e;
             }

--- a/src/Subreddit/UserNotes.ts
+++ b/src/Subreddit/UserNotes.ts
@@ -16,6 +16,7 @@ import {Cache} from 'cache-manager';
 import {isScopeError} from "../Utils/Errors";
 import {ErrorWithCause} from "pony-cause";
 import {UserNoteType} from "../Common/Infrastructure/Atomic";
+import {CMCache} from "../Common/Cache";
 
 interface RawUserNotesPayload {
     ver: number,
@@ -67,7 +68,7 @@ export class UserNotes {
     moderators?: RedditUser[];
     logger: Logger;
     identifier: string;
-    cache: Cache
+    cache: CMCache
     cacheCB: Function;
     mod?: RedditUser;
 
@@ -77,7 +78,7 @@ export class UserNotes {
     debounceCB: any;
     batchCount: number = 0;
 
-    constructor(ttl: number | boolean, subreddit: string, client: Snoowrap, logger: Logger, cache: Cache, cacheCB: Function) {
+    constructor(ttl: number | boolean, subreddit: string, client: Snoowrap, logger: Logger, cache: CMCache, cacheCB: Function) {
         this.notesTTL = ttl === true ? 0 : ttl;
         this.subreddit = client.getSubreddit(subreddit);
         this.logger = logger;

--- a/src/Web/Client/StorageProvider.ts
+++ b/src/Web/Client/StorageProvider.ts
@@ -1,7 +1,7 @@
 import {SessionOptions, Store} from "express-session";
 import {TypeormStore} from "connect-typeorm";
 import {InviteData} from "../Common/interfaces";
-import {buildCachePrefix, createCacheManager, mergeArr} from "../../util";
+import {buildCachePrefix, mergeArr} from "../../util";
 import {Cache} from "cache-manager";
 // @ts-ignore
 import CacheManagerStore from 'express-session-cache-manager'
@@ -11,6 +11,7 @@ import {ClientSession} from "../../Common/WebEntities/ClientSession";
 import {Logger} from "winston";
 import {WebSetting} from "../../Common/WebEntities/WebSetting";
 import {ErrorWithCause} from "pony-cause";
+import {createCacheManager} from "../../Common/Cache";
 
 export interface CacheManagerStoreOptions {
     prefix?: string

--- a/src/Web/Client/index.ts
+++ b/src/Web/Client/index.ts
@@ -17,7 +17,7 @@ import {
 } from "../../Common/interfaces";
 import {
     buildCachePrefix,
-    createCacheManager, defaultFormat, filterLogBySubreddit, filterCriteriaSummary, formatFilterData,
+    defaultFormat, filterLogBySubreddit, filterCriteriaSummary, formatFilterData,
     formatLogLineToHtml, filterLogs, getUserAgent,
     intersect, isLogLineMinLevel,
     LogEntry, parseInstanceLogInfoName, parseInstanceLogName, parseRedditEntity,
@@ -64,6 +64,7 @@ import {
     InviteData, SubredditInviteDataPersisted
 } from "../Common/interfaces";
 import {open} from "fs/promises";
+import {createCacheManager} from "../../Common/Cache";
 
 const emitter = new EventEmitter();
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,8 +29,8 @@ import {
     RuleResult,
     RuleSetResult,
     RunResult,
-    SearchAndReplaceRegExp,
-    StringComparisonOptions, StrongTTLConfig, TTLConfig
+    SearchAndReplaceRegExp, SharingACLConfig,
+    StringComparisonOptions, StrongSharingACLConfig, StrongTTLConfig, TTLConfig
 } from "./Common/interfaces";
 import InvalidRegexError from "./Utils/InvalidRegexError";
 import {accessSync, constants, promises} from "fs";
@@ -3024,4 +3024,19 @@ export const asStrongImageHashCache = (data: ImageHashCacheData): data is Requir
 export const generateFullWikiUrl = (subreddit: Subreddit | string, location: string) => {
     const subName = subreddit instanceof Subreddit ? subreddit.url : `r/${subreddit}/`;
     return `https://reddit.com${subName}wiki/${location}`
+}
+
+export const toStrongSharingACLConfig = (data: SharingACLConfig | string[]): StrongSharingACLConfig => {
+    if (Array.isArray(data)) {
+        return {
+            include: data.map(x => parseStringToRegexOrLiteralSearch(x))
+        }
+    } else if (data.include !== undefined) {
+        return {
+            include: data.include.map(x => parseStringToRegexOrLiteralSearch(x))
+        }
+    }
+    return {
+        exclude: (data.exclude ?? []).map(x => parseStringToRegexOrLiteralSearch(x))
+    }
 }


### PR DESCRIPTION
TODO

- [x] Get config fragments from wiki or external url
  - [x] Cache fragments using a default (wikiTTL) or [defined value](https://github.com/FoxxMD/context-mod/tree/master/docs/subreddit/components#configuration-re-use-and-caching)
- [x] Detect if fragment is actually entire subreddit config and instead pull `runs` from object
- [x] Refactor subreddit config change detection to account for fragment changes
  - [x] Keep track of fragments found in config
  - [x] Use a hash of config + injected fragments for change detection, alongside wiki revision data
- [x] Add ACL mechanism to prevent subreddits on shared bot from being read by other subreddits
   - Will default to **not shareable** and will require something like `shareTo: *` or `shareTo` as a list to make accessible 